### PR TITLE
fix(serve): handle Ctrl+C on Git Bash and fix scheduler path quoting

### DIFF
--- a/.claude/rules/plan-structure.md
+++ b/.claude/rules/plan-structure.md
@@ -1,0 +1,322 @@
+---
+rule_type: workflow
+applies_to:
+  - "~/.claude/plans/*.md"
+  - "Plan file creation"
+  - "Plan execution"
+triggers:
+  - event: "plan_execute"
+    description: "When plan file execution begins - perform Pre-work before implementation"
+  - event: "plan_created"
+    description: "When plan file creation is complete"
+---
+
+# Plan Structure Rules
+
+Rules for structuring plans.
+
+---
+
+## 🔴 Required Actions (Action Required)
+
+> **MUST DO**: You must perform the following actions whenever this rule applies.
+
+### First Task When Executing a Plan (Pre-work)
+
+> ⛔ When the user selects "Start", you **must** perform the following **before reading code or beginning implementation**:
+
+| Order | Check | Condition | Action |
+|:-----:|-------|-----------|--------|
+| 1 | Task count | Task ≥ 3 | Confirm whether to run `/subdivide` **using AskUserQuestion** |
+| 2 | Complexity | Multi-file changes | Confirm whether to run `/review` **using AskUserQuestion** |
+| 3 | Pre-work complete | - | Then begin actual implementation |
+
+#### ✅ AskUserQuestion Usage (Required)
+
+> **CRITICAL**: In **all situations** requiring user confirmation, you **must use the AskUserQuestion tool** instead of plain text.
+
+##### Scope
+
+**Cases where AskUserQuestion is required**:
+1. **Pre-work confirmation**: Whether to run `/subdivide`, `/review` before plan execution
+2. **In-skill confirmation**: Subdivision plan approval during `/subdivide`, next step selection after completion
+3. **Progress confirmation**: All decision points with multiple choices
+4. **Dangerous operations**: Before irreversible operations such as file deletion or overwriting
+
+##### Pre-work Confirmation Example
+
+```json
+{
+  "questions": [{
+    "question": "Would you like to run Pre-work before plan execution?",
+    "header": "Pre-work",
+    "multiSelect": false,
+    "options": [
+      {"label": "Skip and start now", "description": "Begin implementation without Pre-work"},
+      {"label": "Run /subdivide", "description": "Subdivide the plan into detailed task files"},
+      {"label": "Run /review", "description": "Review the plan"}
+    ]
+  }]
+}
+```
+
+##### In-skill Confirmation Example
+
+Subdivision plan approval in `/subdivide` skill:
+```json
+{
+  "questions": [{
+    "question": "Proceed with this subdivision plan?",
+    "header": "Confirm",
+    "multiSelect": false,
+    "options": [
+      {"label": "Proceed", "description": "Start creating files as planned"},
+      {"label": "Needs revision", "description": "Review and revise the plan"},
+      {"label": "Cancel", "description": "Abort subdivision"}
+    ]
+  }]
+}
+```
+
+##### Prohibited
+
+- ❌ Asking as plain text: "Shall I run subdivide?", "Proceed as planned?", "Would you like to start?"
+- ❌ Giving instructions without choices: "Start the task with the following command"
+- ✅ **All confirmations** must use the AskUserQuestion tool
+
+#### ⛔ No Re-searching Plans
+
+- If Plan content is **already in the current conversation context**, do not search/read it again
+- When starting implementation after ExitPlanMode, use the Plan information from context
+- Only read Plan files when a plan execution is requested in a new session
+
+### ⛔ Prohibited
+
+- Starting code reading/implementation without Pre-work
+- Even when a plan execution is requested in a new session, Pre-work must be performed first
+- Jumping straight into implementation after reading a Plan file
+- **Claude must NOT decide to skip `/subdivide` or `/review` on its own**
+  - Cannot skip for reasons like "already detailed enough", "clearly separated", "well-structured"
+  - When conditions are met, you **must ask** the user whether to run them
+  - Skip is only allowed when the user explicitly answers "no"
+
+---
+
+## Linked Skills
+
+<!-- @linked-skills: Skills in this table should be automatically suggested when conditions are met -->
+
+| Skill | Trigger Condition | Execution Mode | Description |
+|-------|-------------------|:--------------:|-------------|
+| `/subdivide` | Task ≥ 3 AND Plan execution starting (Pre-work) | confirm | Subdivide plan into detailed task files |
+| `/review` | Multi-file changes AND Plan execution starting (Pre-work) | confirm | Review plan |
+| `/plan` | When a new plan is needed | auto | Create plan |
+
+**Execution mode descriptions**:
+- `auto`: Execute automatically when conditions are met
+- `confirm`: **Must** ask the user whether to execute when conditions are met (Claude cannot decide to skip on its own)
+- `ask`: Ask the user whether it is needed
+
+**⚠️ `confirm` notes**:
+- Claude cannot **decide to skip on its own** for reasons like "already detailed enough" or "well-separated by task"
+- When the condition (Task ≥ 3) is met, you **must always ask the user**
+- Skip is only allowed when the user explicitly answers "skip", "no", "not needed", etc.
+
+**⛔ Important**: `/subdivide` and `/review` are the **first actions (Pre-work)** of plan execution and must be confirmed before reading code or beginning implementation.
+
+<!-- @/linked-skills -->
+
+---
+
+## When This Applies
+
+- When writing plans in Plan mode
+- When running `/plan`
+- When creating complex work plans
+
+---
+
+## Main Plan File Structure
+
+Main plan files follow this structure:
+
+```markdown
+# {plan title}
+
+> **Created**: YYYY-MM-DD
+> **Purpose**: {one-line description of the plan's purpose}
+
+---
+
+## Implementation Tasks
+
+This plan has been divided into N detailed tasks. Execute them in order.
+
+| Order | Task Name | File | Description |
+|:-----:|-----------|------|-------------|
+| 1 | **Task 1** | [01-task-name.md](./plan-name/01-task-name.md) | Task description |
+| 2 | **Task 2** | [02-task-name.md](./plan-name/02-task-name.md) | Task description |
+| ... | ... | ... | ... |
+
+### Task Rules
+
+1. **Sequential execution**: Proceed in order starting from Task 01
+2. **Checklist**: Check all items in each task before moving to the next
+3. **Lint check**: Run code verification upon completing each task
+4. **Follow links**: Navigate using the "Next Task" link at the bottom of each task file
+
+---
+
+## Core Content
+
+{Core content of the plan...}
+```
+
+---
+
+## Task File Structure
+
+Each task file follows this structure:
+
+```markdown
+# Task {order}: {task name}
+
+> **Order**: {current}/{total}
+> **Previous task**: [{previous task name}](./{previous file}) or (none - first task)
+> **Next task**: [{next task name}](./{next file}) or (none - last task)
+> **Reference**: Original plan {section reference}
+
+---
+
+## Objective
+
+{Description of this task's objective}
+
+---
+
+## Checklist
+
+### 1. {First step}
+
+- [ ] {Sub-task 1}
+- [ ] {Sub-task 2}
+  - Code examples or detailed descriptions may be included
+
+### 2. {Second step}
+
+- [ ] {Sub-task 3}
+- [ ] {Sub-task 4}
+
+---
+
+## Completion Criteria
+
+1. All Checklist items checked
+2. Build succeeds (if applicable)
+3. Tests pass (if applicable)
+
+---
+
+## Verification Commands
+
+Run the following commands after completing the task:
+
+\`\`\`bash
+{verification commands appropriate for the project}
+\`\`\`
+
+---
+
+## Next Task
+
+After verification passes, proceed to the next task:
+
+**[Task {next order}: {next task name}](./{next file})**
+
+In the next task:
+- {Next task summary 1}
+- {Next task summary 2}
+
+---
+
+*Created: YYYY-MM-DD*
+```
+
+---
+
+## Subdivision Criteria
+
+Criteria for splitting a plan into detailed tasks:
+
+### When to Subdivide
+
+1. **Independent deliverables**: Each task can be completed independently
+2. **Logical stages**: Steps that must proceed sequentially
+3. **Different areas**: Different code/file areas
+4. **Verifiable**: Each task can be verified after completion
+
+### Subdivision Examples
+
+| Task Type | Subdivision Unit |
+|-----------|-----------------|
+| Adding entities | Domain → Repository → Service → Controller |
+| API development | Per endpoint or per feature |
+| Refactoring | Per module or per layer |
+| Migration | By stage (Preparation → Execution → Verification → Cleanup) |
+
+---
+
+## File Naming Conventions
+
+### Main Plan
+
+- Location: `~/.claude/plans/{plan-name}.md`
+- Naming: Use the auto-generated name from Claude
+
+### Task Files Folder
+
+- Location: `~/.claude/plans/{plan-name}/`
+- Files: `{2-digit-order}-{task-name-kebab-case}.md`
+
+### Example
+
+```
+~/.claude/plans/
+├── jaunty-greeting-puffin.md           # Main plan
+└── jaunty-greeting-puffin/             # Task files folder
+    ├── 01-campaign-response-entity.md
+    ├── 02-evaluation-result-entity.md
+    ├── 03-audit-log-enhancement.md
+    ├── 04-service-expansion.md
+    ├── 05-api-migration.md
+    └── 06-submission-removal.md
+```
+
+---
+
+## Checklist Writing Guidelines
+
+### Good Checklists
+
+- [ ] **Specific**: Clearly states what needs to be done
+- [ ] **Verifiable**: Completion can be determined
+- [ ] **Independent**: No overlap with other items
+- [ ] **Ordered**: Arranged by dependency order
+
+### Including Code Examples
+
+If a checklist item needs a code example, include it with indentation:
+
+```markdown
+- [ ] Create `UserService.kt`
+  ```kotlin
+  interface UserService {
+      fun getUser(id: Long): User
+  }
+  ```
+```
+
+---
+
+*This rule is automatically referenced by Plan mode and other plan-writing agents.*
+*Last modified: 2026-02-05*

--- a/.claude/rules/rule-format.md
+++ b/.claude/rules/rule-format.md
@@ -1,0 +1,276 @@
+---
+rule_type: meta
+applies_to:
+  - "~/.claude/rules/*.md"
+  - "project/.claude/rules/*.md"
+triggers:
+  - event: "rule_create"
+    description: "When creating a new rule file"
+  - event: "rule_update"
+    description: "When modifying an existing rule file"
+---
+
+# Rule File Format Standard
+
+The format standard to follow when writing rule files.
+
+---
+
+## 🔴 Required Actions (Action Required)
+
+> **MUST DO**: Follow the format below when creating/modifying rule files.
+
+### When Creating a Rule File (on-create)
+
+| Check | Action |
+|-------|--------|
+| File type classification | Choose from workflow / reference / meta |
+| Write Frontmatter | Define rule_type, applies_to, triggers |
+| Check linked skills | If related skills/agents exist, write Linked Skills table |
+
+### When Modifying a Rule File (on-update)
+
+| Check | Action |
+|-------|--------|
+| Format validation | Run `/rule-validator` to verify format compliance |
+
+---
+
+## Linked Skills
+
+<!-- @linked-skills -->
+
+| Skill | Trigger Condition | Execution Mode | Description |
+|-------|-------------------|:--------------:|-------------|
+| `/rule-validator` | When creating/modifying rule files | confirm | Format validation and conversion |
+
+<!-- @/linked-skills -->
+
+---
+
+## 1. Rule File Types (rule_type)
+
+| Type | Description | Frontmatter Required | Linked Skills Table |
+|------|-------------|:--------------------:|:-------------------:|
+| **workflow** | Defines behavior/procedures (has execution order) | ✅ Required | ✅ Required |
+| **reference** | Reference information (conventions, guides) | ⚠️ Recommended | ⚠️ Optional |
+| **meta** | Rules about rules | ✅ Required | ✅ Required |
+
+### Characteristics by Type
+
+```
+workflow:  "Do it this way" → Requires behavior triggers
+reference: "Refer to this" → Provides information
+meta:      "Write rules this way" → Meta rules
+```
+
+---
+
+## 2. Frontmatter Structure
+
+### Required Fields
+
+```yaml
+---
+rule_type: workflow | reference | meta
+applies_to:
+  - "Target pattern or situation"
+triggers:
+  - event: "event_name"
+    description: "description"
+---
+```
+
+### Field Descriptions
+
+| Field | Required | Description |
+|-------|:--------:|-------------|
+| `rule_type` | ✅ | Rule type (workflow/reference/meta) |
+| `applies_to` | ✅ | Target scope (file patterns, situation descriptions) |
+| `triggers` | ⚠️ | Trigger events (required only for workflow/meta) |
+
+### Trigger Event Examples
+
+| Event | Description |
+|-------|-------------|
+| `plan_execute` | When executing a plan file |
+| `plan_created` | When plan file creation is complete |
+| `code_commit` | Before code commit |
+| `file_create` | When creating a file |
+| `file_modify` | When modifying a file |
+| `server_start` | When server start is requested |
+| `test_write` | When writing tests |
+| `doc_write` | When writing documentation |
+| `code_review` | When reviewing code |
+
+---
+
+## 3. Required Actions Section
+
+Must be included for workflow/meta types:
+
+```markdown
+## 🔴 Required Actions (Action Required)
+
+> **MUST DO**: You must perform the following actions whenever this rule applies.
+
+### {Situation} ({event name})
+
+| Check | Condition | Action |
+|-------|-----------|--------|
+| {What to check} | {condition} | {action to perform} |
+```
+
+### Writing Guidelines
+
+- Use `🔴` emoji for visual emphasis
+- Use `> **MUST DO**` blockquote to indicate mandatory nature
+- Structure with tables for clear action directives
+
+---
+
+## 4. Linked Skills Table
+
+When integration with skills/agents is needed:
+
+```markdown
+## Linked Skills
+
+<!-- @linked-skills -->
+
+| Skill | Trigger Condition | Execution Mode | Description |
+|-------|-------------------|:--------------:|-------------|
+| `/skill-name` | condition | auto/confirm/ask | description |
+| `agent-name` | condition | auto/confirm/ask | description |
+
+<!-- @/linked-skills -->
+```
+
+### Execution Modes
+
+| Mode | Description |
+|------|-------------|
+| `auto` | Execute automatically when conditions are met |
+| `confirm` | Ask the user whether to execute when conditions are met (include recommended message) |
+| `ask` | Ask the user whether it is needed |
+
+### Marker Tags
+
+```markdown
+<!-- @linked-skills -->
+...table...
+<!-- @/linked-skills -->
+```
+
+- `/rule-validator` recognizes these markers for validation
+- Extracts skill integration info in a parseable structure
+
+---
+
+## 5. Document Structure
+
+### workflow Type
+
+```markdown
+---
+(Frontmatter)
+---
+
+# Rule Title
+
+Description...
+
+---
+
+## 🔴 Required Actions (Action Required)
+(required)
+
+---
+
+## Linked Skills
+(required)
+
+---
+
+## Detailed Content
+...
+
+---
+
+*Related files/docs*: ...
+*Last modified*: YYYY-MM-DD
+```
+
+### reference Type
+
+```markdown
+---
+(Frontmatter - optional)
+---
+
+# Rule Title
+
+Description...
+
+---
+
+## Content Sections
+...
+
+---
+
+## Linked Skills
+(optional - add if a validation agent exists)
+
+---
+
+*Related files/docs*: ...
+```
+
+---
+
+## 6. Examples
+
+### workflow Example (environment-setup.md)
+
+```yaml
+---
+rule_type: workflow
+applies_to:
+  - "Server start/stop"
+  - "Development environment setup"
+triggers:
+  - event: "server_start"
+    description: "When server start is requested"
+---
+```
+
+### reference Example (naming-conventions.md)
+
+```yaml
+---
+rule_type: reference
+applies_to:
+  - "*.kt file creation"
+  - "Class/method naming"
+---
+```
+
+---
+
+## 7. Validation Checklist
+
+Verify when writing/modifying rule files:
+
+- [ ] Frontmatter included (required for workflow/meta)
+- [ ] rule_type specified
+- [ ] applies_to specified
+- [ ] triggers specified (workflow/meta)
+- [ ] Required Actions section included (workflow/meta)
+- [ ] Linked Skills table included (when skill integration exists)
+- [ ] `<!-- @linked-skills -->` markers used
+
+---
+
+*This rule is referenced when writing any rule file.*
+*Last modified: 2026-02-05*

--- a/scheduler.py
+++ b/scheduler.py
@@ -163,15 +163,20 @@ def install_schedule(schedule_time="23:30"):
     
     cwd = os.getcwd()
     log_file_path = os.path.join(cwd, SCHEDULER_LOG)
-    cmd_str = f"cd {cwd} && {python_executable} -m claw_log.main >> {log_file_path} 2>&1"
-    
+    # 경로에 공백이 포함될 수 있으므로 모든 경로를 따옴표로 감쌈.
+    # cd /d: 드라이브 전환도 함께 처리 (C: → D: 등).
+    cmd_str = (
+        f'cd /d "{cwd}" && '
+        f'"{python_executable}" -m claw_log.main >> "{log_file_path}" 2>&1'
+    )
+
     print(f"\n🕒 [{system}] 스케줄러 등록 작업 시작...")
     print(f"   - 실행 시각: 매일 {hour}:{minute}")
     print(f"   - 실행 경로: {cwd}")
     print(f"   - 로그 파일: {log_file_path}")
 
     if system == "Windows":
-        win_cmd = f'cmd /c "{cmd_str}"'
+        win_cmd = f"cmd /d /c {cmd_str}"
         try:
             subprocess.run([
                 "schtasks", "/Create", "/SC", "DAILY", "/TN", WIN_TASK_NAME,


### PR DESCRIPTION
## Summary
- **server.py**: Git Bash(mintty)에서 Ctrl+C가 native Windows 프로세스로 전달되지 않는 문제 수정. `SIGINT`/`SIGBREAK` 핸들러 명시 등록 + `server.shutdown()`을 daemon 스레드에서 호출
- **scheduler.py**: Windows Task Scheduler 명령어의 경로 quoting 누락 수정. `cd /d` + 모든 경로 따옴표 처리 + `cmd /d /c` AutoRun 비활성화

## Root Cause (Codex GPT-5.3 교차 검증)
1. **Ctrl+C**: mintty 터미널이 SIGINT를 native Windows 프로세스에 신뢰성 있게 전달하지 않음 (터미널 signal bridge 문제)
2. **Scheduler**: 경로에 공백 포함 시 `cd`/`python`/`log_file_path`가 인자 분리되어 명령 실패. `cd`는 드라이브 전환 불가

## Test plan
- [ ] `claw-log --serve` 실행 후 Git Bash에서 Ctrl+C로 정상 종료 확인
- [ ] `claw-log --serve` 실행 후 PowerShell/cmd에서 Ctrl+C로 정상 종료 확인
- [ ] `claw-log --schedule 23:30` 등록 후 `schtasks /Query /TN ClawLog_Daily /FO LIST /V`로 명령어 확인
- [ ] `schtasks /Run /TN ClawLog_Daily` 즉시 실행 테스트 → `scheduler.log` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)