### PR TITLE
feat: add commit deduplication tracking to prevent duplicate summaries

### DIFF
--- a/.claude/rules/plan-structure.md
+++ b/.claude/rules/plan-structure.md
@@ -1,0 +1,322 @@
+---
+rule_type: workflow
+applies_to:
+  - "~/.claude/plans/*.md"
+  - "Plan file creation"
+  - "Plan execution"
+triggers:
+  - event: "plan_execute"
+    description: "When plan file execution begins - perform Pre-work before implementation"
+  - event: "plan_created"
+    description: "When plan file creation is complete"
+---
+
+# Plan Structure Rules
+
+Rules for structuring plans.
+
+---
+
+## 🔴 Required Actions (Action Required)
+
+> **MUST DO**: You must perform the following actions whenever this rule applies.
+
+### First Task When Executing a Plan (Pre-work)
+
+> ⛔ When the user selects "Start", you **must** perform the following **before reading code or beginning implementation**:
+
+| Order | Check | Condition | Action |
+|:-----:|-------|-----------|--------|
+| 1 | Task count | Task ≥ 3 | Confirm whether to run `/subdivide` **using AskUserQuestion** |
+| 2 | Complexity | Multi-file changes | Confirm whether to run `/review` **using AskUserQuestion** |
+| 3 | Pre-work complete | - | Then begin actual implementation |
+
+#### ✅ AskUserQuestion Usage (Required)
+
+> **CRITICAL**: In **all situations** requiring user confirmation, you **must use the AskUserQuestion tool** instead of plain text.
+
+##### Scope
+
+**Cases where AskUserQuestion is required**:
+1. **Pre-work confirmation**: Whether to run `/subdivide`, `/review` before plan execution
+2. **In-skill confirmation**: Subdivision plan approval during `/subdivide`, next step selection after completion
+3. **Progress confirmation**: All decision points with multiple choices
+4. **Dangerous operations**: Before irreversible operations such as file deletion or overwriting
+
+##### Pre-work Confirmation Example
+
+```json
+{
+  "questions": [{
+    "question": "Would you like to run Pre-work before plan execution?",
+    "header": "Pre-work",
+    "multiSelect": false,
+    "options": [
+      {"label": "Skip and start now", "description": "Begin implementation without Pre-work"},
+      {"label": "Run /subdivide", "description": "Subdivide the plan into detailed task files"},
+      {"label": "Run /review", "description": "Review the plan"}
+    ]
+  }]
+}
+```
+
+##### In-skill Confirmation Example
+
+Subdivision plan approval in `/subdivide` skill:
+```json
+{
+  "questions": [{
+    "question": "Proceed with this subdivision plan?",
+    "header": "Confirm",
+    "multiSelect": false,
+    "options": [
+      {"label": "Proceed", "description": "Start creating files as planned"},
+      {"label": "Needs revision", "description": "Review and revise the plan"},
+      {"label": "Cancel", "description": "Abort subdivision"}
+    ]
+  }]
+}
+```
+
+##### Prohibited
+
+- ❌ Asking as plain text: "Shall I run subdivide?", "Proceed as planned?", "Would you like to start?"
+- ❌ Giving instructions without choices: "Start the task with the following command"
+- ✅ **All confirmations** must use the AskUserQuestion tool
+
+#### ⛔ No Re-searching Plans
+
+- If Plan content is **already in the current conversation context**, do not search/read it again
+- When starting implementation after ExitPlanMode, use the Plan information from context
+- Only read Plan files when a plan execution is requested in a new session
+
+### ⛔ Prohibited
+
+- Starting code reading/implementation without Pre-work
+- Even when a plan execution is requested in a new session, Pre-work must be performed first
+- Jumping straight into implementation after reading a Plan file
+- **Claude must NOT decide to skip `/subdivide` or `/review` on its own**
+  - Cannot skip for reasons like "already detailed enough", "clearly separated", "well-structured"
+  - When conditions are met, you **must ask** the user whether to run them
+  - Skip is only allowed when the user explicitly answers "no"
+
+---
+
+## Linked Skills
+
+<!-- @linked-skills: Skills in this table should be automatically suggested when conditions are met -->
+
+| Skill | Trigger Condition | Execution Mode | Description |
+|-------|-------------------|:--------------:|-------------|
+| `/subdivide` | Task ≥ 3 AND Plan execution starting (Pre-work) | confirm | Subdivide plan into detailed task files |
+| `/review` | Multi-file changes AND Plan execution starting (Pre-work) | confirm | Review plan |
+| `/plan` | When a new plan is needed | auto | Create plan |
+
+**Execution mode descriptions**:
+- `auto`: Execute automatically when conditions are met
+- `confirm`: **Must** ask the user whether to execute when conditions are met (Claude cannot decide to skip on its own)
+- `ask`: Ask the user whether it is needed
+
+**⚠️ `confirm` notes**:
+- Claude cannot **decide to skip on its own** for reasons like "already detailed enough" or "well-separated by task"
+- When the condition (Task ≥ 3) is met, you **must always ask the user**
+- Skip is only allowed when the user explicitly answers "skip", "no", "not needed", etc.
+
+**⛔ Important**: `/subdivide` and `/review` are the **first actions (Pre-work)** of plan execution and must be confirmed before reading code or beginning implementation.
+
+<!-- @/linked-skills -->
+
+---
+
+## When This Applies
+
+- When writing plans in Plan mode
+- When running `/plan`
+- When creating complex work plans
+
+---
+
+## Main Plan File Structure
+
+Main plan files follow this structure:
+
+```markdown
+# {plan title}
+
+> **Created**: YYYY-MM-DD
+> **Purpose**: {one-line description of the plan's purpose}
+
+---
+
+## Implementation Tasks
+
+This plan has been divided into N detailed tasks. Execute them in order.
+
+| Order | Task Name | File | Description |
+|:-----:|-----------|------|-------------|
+| 1 | **Task 1** | [01-task-name.md](./plan-name/01-task-name.md) | Task description |
+| 2 | **Task 2** | [02-task-name.md](./plan-name/02-task-name.md) | Task description |
+| ... | ... | ... | ... |
+
+### Task Rules
+
+1. **Sequential execution**: Proceed in order starting from Task 01
+2. **Checklist**: Check all items in each task before moving to the next
+3. **Lint check**: Run code verification upon completing each task
+4. **Follow links**: Navigate using the "Next Task" link at the bottom of each task file
+
+---
+
+## Core Content
+
+{Core content of the plan...}
+```
+
+---
+
+## Task File Structure
+
+Each task file follows this structure:
+
+```markdown
+# Task {order}: {task name}
+
+> **Order**: {current}/{total}
+> **Previous task**: [{previous task name}](./{previous file}) or (none - first task)
+> **Next task**: [{next task name}](./{next file}) or (none - last task)
+> **Reference**: Original plan {section reference}
+
+---
+
+## Objective
+
+{Description of this task's objective}
+
+---
+
+## Checklist
+
+### 1. {First step}
+
+- [ ] {Sub-task 1}
+- [ ] {Sub-task 2}
+  - Code examples or detailed descriptions may be included
+
+### 2. {Second step}
+
+- [ ] {Sub-task 3}
+- [ ] {Sub-task 4}
+
+---
+
+## Completion Criteria
+
+1. All Checklist items checked
+2. Build succeeds (if applicable)
+3. Tests pass (if applicable)
+
+---
+
+## Verification Commands
+
+Run the following commands after completing the task:
+
+\`\`\`bash
+{verification commands appropriate for the project}
+\`\`\`
+
+---
+
+## Next Task
+
+After verification passes, proceed to the next task:
+
+**[Task {next order}: {next task name}](./{next file})**
+
+In the next task:
+- {Next task summary 1}
+- {Next task summary 2}
+
+---
+
+*Created: YYYY-MM-DD*
+```
+
+---
+
+## Subdivision Criteria
+
+Criteria for splitting a plan into detailed tasks:
+
+### When to Subdivide
+
+1. **Independent deliverables**: Each task can be completed independently
+2. **Logical stages**: Steps that must proceed sequentially
+3. **Different areas**: Different code/file areas
+4. **Verifiable**: Each task can be verified after completion
+
+### Subdivision Examples
+
+| Task Type | Subdivision Unit |
+|-----------|-----------------|
+| Adding entities | Domain → Repository → Service → Controller |
+| API development | Per endpoint or per feature |
+| Refactoring | Per module or per layer |
+| Migration | By stage (Preparation → Execution → Verification → Cleanup) |
+
+---
+
+## File Naming Conventions
+
+### Main Plan
+
+- Location: `~/.claude/plans/{plan-name}.md`
+- Naming: Use the auto-generated name from Claude
+
+### Task Files Folder
+
+- Location: `~/.claude/plans/{plan-name}/`
+- Files: `{2-digit-order}-{task-name-kebab-case}.md`
+
+### Example
+
+```
+~/.claude/plans/
+├── jaunty-greeting-puffin.md           # Main plan
+└── jaunty-greeting-puffin/             # Task files folder
+    ├── 01-campaign-response-entity.md
+    ├── 02-evaluation-result-entity.md
+    ├── 03-audit-log-enhancement.md
+    ├── 04-service-expansion.md
+    ├── 05-api-migration.md
+    └── 06-submission-removal.md
+```
+
+---
+
+## Checklist Writing Guidelines
+
+### Good Checklists
+
+- [ ] **Specific**: Clearly states what needs to be done
+- [ ] **Verifiable**: Completion can be determined
+- [ ] **Independent**: No overlap with other items
+- [ ] **Ordered**: Arranged by dependency order
+
+### Including Code Examples
+
+If a checklist item needs a code example, include it with indentation:
+
+```markdown
+- [ ] Create `UserService.kt`
+  ```kotlin
+  interface UserService {
+      fun getUser(id: Long): User
+  }
+  ```
+```
+
+---
+
+*This rule is automatically referenced by Plan mode and other plan-writing agents.*
+*Last modified: 2026-02-05*

--- a/.claude/rules/rule-format.md
+++ b/.claude/rules/rule-format.md
@@ -1,0 +1,276 @@
+---
+rule_type: meta
+applies_to:
+  - "~/.claude/rules/*.md"
+  - "project/.claude/rules/*.md"
+triggers:
+  - event: "rule_create"
+    description: "When creating a new rule file"
+  - event: "rule_update"
+    description: "When modifying an existing rule file"
+---
+
+# Rule File Format Standard
+
+The format standard to follow when writing rule files.
+
+---
+
+## 🔴 Required Actions (Action Required)
+
+> **MUST DO**: Follow the format below when creating/modifying rule files.
+
+### When Creating a Rule File (on-create)
+
+| Check | Action |
+|-------|--------|
+| File type classification | Choose from workflow / reference / meta |
+| Write Frontmatter | Define rule_type, applies_to, triggers |
+| Check linked skills | If related skills/agents exist, write Linked Skills table |
+
+### When Modifying a Rule File (on-update)
+
+| Check | Action |
+|-------|--------|
+| Format validation | Run `/rule-validator` to verify format compliance |
+
+---
+
+## Linked Skills
+
+<!-- @linked-skills -->
+
+| Skill | Trigger Condition | Execution Mode | Description |
+|-------|-------------------|:--------------:|-------------|
+| `/rule-validator` | When creating/modifying rule files | confirm | Format validation and conversion |
+
+<!-- @/linked-skills -->
+
+---
+
+## 1. Rule File Types (rule_type)
+
+| Type | Description | Frontmatter Required | Linked Skills Table |
+|------|-------------|:--------------------:|:-------------------:|
+| **workflow** | Defines behavior/procedures (has execution order) | ✅ Required | ✅ Required |
+| **reference** | Reference information (conventions, guides) | ⚠️ Recommended | ⚠️ Optional |
+| **meta** | Rules about rules | ✅ Required | ✅ Required |
+
+### Characteristics by Type
+
+```
+workflow:  "Do it this way" → Requires behavior triggers
+reference: "Refer to this" → Provides information
+meta:      "Write rules this way" → Meta rules
+```
+
+---
+
+## 2. Frontmatter Structure
+
+### Required Fields
+
+```yaml
+---
+rule_type: workflow | reference | meta
+applies_to:
+  - "Target pattern or situation"
+triggers:
+  - event: "event_name"
+    description: "description"
+---
+```
+
+### Field Descriptions
+
+| Field | Required | Description |
+|-------|:--------:|-------------|
+| `rule_type` | ✅ | Rule type (workflow/reference/meta) |
+| `applies_to` | ✅ | Target scope (file patterns, situation descriptions) |
+| `triggers` | ⚠️ | Trigger events (required only for workflow/meta) |
+
+### Trigger Event Examples
+
+| Event | Description |
+|-------|-------------|
+| `plan_execute` | When executing a plan file |
+| `plan_created` | When plan file creation is complete |
+| `code_commit` | Before code commit |
+| `file_create` | When creating a file |
+| `file_modify` | When modifying a file |
+| `server_start` | When server start is requested |
+| `test_write` | When writing tests |
+| `doc_write` | When writing documentation |
+| `code_review` | When reviewing code |
+
+---
+
+## 3. Required Actions Section
+
+Must be included for workflow/meta types:
+
+```markdown
+## 🔴 Required Actions (Action Required)
+
+> **MUST DO**: You must perform the following actions whenever this rule applies.
+
+### {Situation} ({event name})
+
+| Check | Condition | Action |
+|-------|-----------|--------|
+| {What to check} | {condition} | {action to perform} |
+```
+
+### Writing Guidelines
+
+- Use `🔴` emoji for visual emphasis
+- Use `> **MUST DO**` blockquote to indicate mandatory nature
+- Structure with tables for clear action directives
+
+---
+
+## 4. Linked Skills Table
+
+When integration with skills/agents is needed:
+
+```markdown
+## Linked Skills
+
+<!-- @linked-skills -->
+
+| Skill | Trigger Condition | Execution Mode | Description |
+|-------|-------------------|:--------------:|-------------|
+| `/skill-name` | condition | auto/confirm/ask | description |
+| `agent-name` | condition | auto/confirm/ask | description |
+
+<!-- @/linked-skills -->
+```
+
+### Execution Modes
+
+| Mode | Description |
+|------|-------------|
+| `auto` | Execute automatically when conditions are met |
+| `confirm` | Ask the user whether to execute when conditions are met (include recommended message) |
+| `ask` | Ask the user whether it is needed |
+
+### Marker Tags
+
+```markdown
+<!-- @linked-skills -->
+...table...
+<!-- @/linked-skills -->
+```
+
+- `/rule-validator` recognizes these markers for validation
+- Extracts skill integration info in a parseable structure
+
+---
+
+## 5. Document Structure
+
+### workflow Type
+
+```markdown
+---
+(Frontmatter)
+---
+
+# Rule Title
+
+Description...
+
+---
+
+## 🔴 Required Actions (Action Required)
+(required)
+
+---
+
+## Linked Skills
+(required)
+
+---
+
+## Detailed Content
+...
+
+---
+
+*Related files/docs*: ...
+*Last modified*: YYYY-MM-DD
+```
+
+### reference Type
+
+```markdown
+---
+(Frontmatter - optional)
+---
+
+# Rule Title
+
+Description...
+
+---
+
+## Content Sections
+...
+
+---
+
+## Linked Skills
+(optional - add if a validation agent exists)
+
+---
+
+*Related files/docs*: ...
+```
+
+---
+
+## 6. Examples
+
+### workflow Example (environment-setup.md)
+
+```yaml
+---
+rule_type: workflow
+applies_to:
+  - "Server start/stop"
+  - "Development environment setup"
+triggers:
+  - event: "server_start"
+    description: "When server start is requested"
+---
+```
+
+### reference Example (naming-conventions.md)
+
+```yaml
+---
+rule_type: reference
+applies_to:
+  - "*.kt file creation"
+  - "Class/method naming"
+---
+```
+
+---
+
+## 7. Validation Checklist
+
+Verify when writing/modifying rule files:
+
+- [ ] Frontmatter included (required for workflow/meta)
+- [ ] rule_type specified
+- [ ] applies_to specified
+- [ ] triggers specified (workflow/meta)
+- [ ] Required Actions section included (workflow/meta)
+- [ ] Linked Skills table included (when skill integration exists)
+- [ ] `<!-- @linked-skills -->` markers used
+
+---
+
+*This rule is referenced when writing any rule file.*
+*Last modified: 2026-02-05*

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv
 from claw_log.engine import GeminiSummarizer, OpenAISummarizer, CodexOAuthSummarizer
 from claw_log.storage import prepend_to_log_file, read_recent_logs, LOG_FILENAME
 from claw_log.scheduler import install_schedule, show_schedule, remove_schedule, get_schedule_summary
+from claw_log.state import load_state, save_state, get_last_hash, update_last_hash
 
 # .env 파일은 현재 작업 디렉토리(CWD)에서 찾습니다.
 ENV_PATH = Path(os.getcwd()) / ".env"
@@ -296,6 +297,17 @@ def show_status():
     else:
         print(f"  로그파일:  없음 (첫 실행 전)")
 
+    # 커밋 추적 상태
+    try:
+        tracking_state = load_state()
+        n = len(tracking_state.get("projects", {}))
+        if n:
+            print(f"  추적상태:  {n}개 프로젝트 커밋 추적 중")
+        else:
+            print(f"  추적상태:  초기 상태")
+    except Exception:
+        print(f"  추적상태:  조회 실패")
+
     print("━" * 40)
 
 
@@ -444,7 +456,7 @@ def run_wizard():
 # ── Git Diff 수집 ──
 
 def _get_repo_key(path):
-    """repo_root + ref_name으로 고유 키 생성 (브랜치별 독립 추적)."""
+    """R2-#1: repo_root + ref_name으로 고유 키 생성 (브랜치별 독립 추적)."""
     try:
         repo_root = subprocess.check_output(
             ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
@@ -492,7 +504,7 @@ def _get_latest_commit_hash(path):
 
 
 def _count_commits_in_range(path, from_hash, to_ref="HEAD"):
-    """두 지점 사이의 커밋 수를 반환. 실패 시 -1."""
+    """R2-#5: 두 지점 사이의 커밋 수를 반환. 실패 시 -1."""
     try:
         count_str = subprocess.check_output(
             ["git", "-C", str(path), "rev-list", "--count", f"{from_hash}..{to_ref}"],
@@ -503,19 +515,31 @@ def _count_commits_in_range(path, from_hash, to_ref="HEAD"):
         return -1
 
 
-def get_git_diff_for_path(path_str, days=0):
-    """Git diff를 수집합니다. days=0이면 오늘만, days>0이면 과거 N일치."""
+def get_git_diff_for_path(path_str, days=0, last_hash=None):
+    """Git diff를 수집합니다. days=0이면 오늘만, days>0이면 과거 N일치.
+
+    Args:
+        path_str: Git 저장소 경로
+        days: 과거 N일치 수집 (0이면 오늘 또는 last_hash 이후)
+        last_hash: 마지막 처리된 커밋 해시 (None이면 날짜 기반 fallback)
+
+    Returns:
+        (diff_str, truncated, commit_count) 3-tuple.
+        diff_str: 수집된 diff 문자열 (없으면 None)
+        truncated: 15,000자 초과 여부
+        commit_count: 수집 범위의 총 커밋 수 (-1은 fallback 모드)
+    """
     path = Path(path_str).resolve()
 
     if not path.exists():
-        print(f"⚠️  경로를 찾을 수 없습니다: {path}")
-        print("   👉 폴더 주소가 정확한지 확인해주세요.")
-        return None
+        print(f"   경로를 찾을 수 없습니다: {path}")
+        print("   폴더 주소가 정확한지 확인해주세요.")
+        return (None, False, 0)
 
     if not (path / ".git").exists():
-        print(f"⚠️  Git 저장소가 아닙니다 (건너뜀): {path}")
-        print("   👉 해당 폴더에 .git 디렉토리가 있는지 확인해주세요.")
-        return None
+        print(f"   Git 저장소가 아닙니다 (건너뜀): {path}")
+        print("   해당 폴더에 .git 디렉토리가 있는지 확인해주세요.")
+        return (None, False, 0)
 
     exclude_patterns = [
         ":(exclude)package-lock.json", ":(exclude)yarn.lock", ":(exclude)pnpm-lock.yaml",
@@ -523,16 +547,41 @@ def get_git_diff_for_path(path_str, days=0):
         ":(exclude)node_modules/", ":(exclude).next/", ":(exclude).git/", ":(exclude).DS_Store"
     ]
 
+    max_count_args = ["--max-count=50"]
+    commit_count = 0
+
     try:
         combined_result = ""
         since_date = datetime.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
         if days > 0:
             since_date -= datetime.timedelta(days=days)
 
-        # 1. 커밋 로그
+        # 1. 커밋 로그 수집 (분기)
         period_label = f"Past {days} Days" if days > 0 else "Today"
         try:
-            cmd_log = ["git", "-C", str(path), "log", f"--since={since_date.isoformat()}", "-p", "--", "."] + exclude_patterns
+            if last_hash and _is_valid_ancestor(path, last_hash):
+                # R2-#5: 총 커밋 수 확인 후 max-count 제한으로 수집
+                total_in_range = _count_commits_in_range(path, last_hash)
+                cmd_log = (
+                    ["git", "-C", str(path), "log", f"{last_hash}..HEAD"]
+                    + max_count_args + ["-p", "--", "."] + exclude_patterns
+                )
+                commit_count = total_in_range
+            elif last_hash:
+                # R2-#3: 무효 해시 → commit count 기반 복구 (최근 100개)
+                cmd_log = (
+                    ["git", "-C", str(path), "log", "-n", "100", "-p", "--", "."]
+                    + exclude_patterns
+                )
+                p_name = Path(path_str).name
+                print(f"  [{p_name}] 저장된 커밋 해시가 유효하지 않아 최근 커밋을 스캔합니다.")
+                commit_count = -1  # fallback 모드
+            else:
+                cmd_log = (
+                    ["git", "-C", str(path), "log", f"--since={since_date.isoformat()}"]
+                    + max_count_args + ["-p", "--", "."] + exclude_patterns
+                )
+
             log_output = subprocess.check_output(cmd_log, stderr=subprocess.STDOUT).decode("utf-8")
             if log_output.strip():
                 combined_result += f"=== [Past Commits ({period_label})] ===\n" + log_output + "\n\n"
@@ -548,10 +597,11 @@ def get_git_diff_for_path(path_str, days=0):
         except subprocess.CalledProcessError:
             pass
 
-        return combined_result if combined_result.strip() else None
+        truncated = len(combined_result) > 15000
+        return (combined_result if combined_result.strip() else None, truncated, commit_count)
 
     except Exception:
-        return None
+        return (None, False, 0)
 
 
 # ── 환경 점검 ──
@@ -654,19 +704,29 @@ def main():
 
         total_chars = 0
         collected = 0
+        dry_state = load_state()
         for repo_path_str in target_paths:
             p_name = Path(repo_path_str).name
-            diff = get_git_diff_for_path(repo_path_str)
+            repo_key = _get_repo_key(repo_path_str)
+            last_hash = get_last_hash(dry_state, repo_key)
+            diff, truncated, commit_count = get_git_diff_for_path(repo_path_str, last_hash=last_hash)
             if diff:
                 chars = len(diff)
-                truncated = min(chars, 15000)
-                total_chars += truncated
+                truncated_chars = min(chars, 15000)
+                total_chars += truncated_chars
                 collected += 1
-                print(f"  ✅ [{p_name}] {chars:,}자 (전송: {truncated:,}자)")
+                status = ""
+                if truncated:
+                    status += " (truncated)"
+                if commit_count > 50:
+                    status += f" ({commit_count}커밋 중 50개만)"
+                elif commit_count == -1:
+                    status += " (fallback 모드)"
+                print(f"  [{p_name}] {chars:,}자 (전송: {truncated_chars:,}자){status}")
             elif Path(repo_path_str).exists():
-                print(f"  ⏭️  [{p_name}] 변경사항 없음")
+                print(f"  [{p_name}] 변경사항 없음")
             else:
-                print(f"  ❌ [{p_name}] 경로 없음")
+                print(f"  [{p_name}] 경로 없음")
 
         print("=" * 50)
         print(f"  수집 프로젝트: {collected}/{len(target_paths)}")
@@ -738,26 +798,52 @@ def main():
         print(f"🚀 Claw-Log 분석 시작 (Engine: {engine_label})...")
 
     # 5. Git 데이터 수집 (선택된 프로젝트만)
+    MAX_COMMITS = 50
     target_paths = [p.strip() for p in paths_env.split(",") if p.strip()]
     combined_diffs = ""
 
+    state = load_state()
+    pending_hashes = {}   # {repo_key: head_hash} — 요약 성공 후 저장할 해시
+    any_truncated = False
+    any_incomplete = False
+
     for repo_path_str in target_paths:
-        diff = get_git_diff_for_path(repo_path_str, days=days)
+        repo_key = _get_repo_key(repo_path_str)
+        last_hash = get_last_hash(state, repo_key) if days == 0 else None
+
+        diff, truncated, commit_count = get_git_diff_for_path(repo_path_str, days=days, last_hash=last_hash)
         if diff:
             p_name = Path(repo_path_str).name
-            print(f"  ✅ [{p_name}] 데이터 수집 완료")
+            print(f"  [{p_name}] 데이터 수집 완료")
             combined_diffs += f"\n--- PROJECT: {p_name} ---\n{diff[:15000]}\n"
+
+            if truncated:
+                any_truncated = True
+                print(f"  [{p_name}] diff가 15,000자를 초과하여 일부만 전송됩니다.")
+
+            # R1-#4 + R2-#5: truncation 또는 커밋 수 초과 시 상태 미업데이트
+            range_complete = (commit_count >= 0 and commit_count <= MAX_COMMITS)
+            should_advance = days == 0 and not truncated and range_complete
+
+            if should_advance:
+                head_hash = _get_latest_commit_hash(repo_path_str)
+                if head_hash:
+                    pending_hashes[repo_key] = head_hash
+            elif days == 0 and commit_count > MAX_COMMITS:
+                any_incomplete = True
+                print(f"  [{p_name}] 커밋 {commit_count}개 중 {MAX_COMMITS}개만 수집 — 추적 상태 미업데이트")
+
         elif Path(repo_path_str).exists():
             p_name = Path(repo_path_str).name
             no_change_label = f"최근 {days}일 변경사항 없음" if days > 0 else "오늘 변경사항 없음"
-            print(f"  ⏭️  [{p_name}] {no_change_label}")
+            print(f"  [{p_name}] {no_change_label}")
 
     if not combined_diffs:
-        print("⚠️  변경사항이 발견되지 않았습니다. (종료)")
+        print("변경사항이 발견되지 않았습니다. (종료)")
         return
 
     # 요약 및 저장
-    print("🤖 AI 요약 생성 중...")
+    print("AI 요약 생성 중...")
     summary = summarizer.summarize(combined_diffs)
 
     if summary and not summary.startswith(("Gemini 요약 생성 실패", "OpenAI 요약 생성 실패")):
@@ -767,10 +853,20 @@ def main():
             saved_file = prepend_to_log_file(summary, date_label=f"{start_date} ~ {end_date}")
         else:
             saved_file = prepend_to_log_file(summary)
-        print(f"\n💾 기록 완료: {saved_file}")
+        print(f"\n기록 완료: {saved_file}")
         print("\n" + "="*60 + f"\n{summary}\n" + "="*60)
+
+        # 요약 성공 후에만 커밋 추적 상태 저장
+        for rk, hh in pending_hashes.items():
+            state = update_last_hash(state, rk, hh)
+        if pending_hashes:
+            save_state(state)
+
+        if any_truncated or any_incomplete:
+            print("  일부 프로젝트의 추적 상태가 업데이트되지 않았습니다.")
+            print("  다음 실행 시 해당 커밋들이 다시 수집됩니다.")
     else:
-        print(f"❌ 요약 실패: {summary}")
+        print(f"요약 실패: {summary}")
 
 if __name__ == "__main__":
     main()

--- a/state.py
+++ b/state.py
@@ -1,0 +1,109 @@
+"""
+Claw-Log State Module
+커밋 추적 상태를 관리하는 모듈. Atomic write + cross-process 파일 락으로 안전하게 저장.
+"""
+
+import json
+import os
+import datetime
+import time
+from pathlib import Path
+
+# oauth.py:30 패턴 재사용
+STATE_DIR = Path.home() / ".claw-log"
+STATE_FILE = STATE_DIR / "commit_state.json"
+LOCK_FILE = STATE_DIR / "commit_state.lock"
+LOCK_TIMEOUT = 10  # seconds
+
+
+def _acquire_lock():
+    """cross-process 파일 락 획득. 타임아웃 시 stale 락 제거."""
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    deadline = time.time() + LOCK_TIMEOUT
+    while True:
+        try:
+            fd = os.open(str(LOCK_FILE), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.write(fd, str(os.getpid()).encode())
+            os.close(fd)
+            return
+        except FileExistsError:
+            # stale 락 체크
+            try:
+                age = time.time() - os.path.getmtime(str(LOCK_FILE))
+                if age > LOCK_TIMEOUT * 3:
+                    os.remove(str(LOCK_FILE))
+                    continue
+            except OSError:
+                pass
+            if time.time() > deadline:
+                # timeout 초과 → 강제 해제
+                try:
+                    os.remove(str(LOCK_FILE))
+                except OSError:
+                    pass
+                continue
+            time.sleep(0.1)
+
+
+def _release_lock():
+    try:
+        os.remove(str(LOCK_FILE))
+    except OSError:
+        pass
+
+
+def load_state():
+    """상태 파일을 로드. 파일 없으면 빈 구조체 반환. 손상 시 .bak 백업 + 경고."""
+    if not STATE_FILE.exists():
+        return {"version": 1, "projects": {}}
+    try:
+        with open(STATE_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict) or "projects" not in data:
+            raise ValueError("Invalid state structure")
+        return data
+    except (json.JSONDecodeError, ValueError):
+        # R2-#4: .bak 백업 + 경고
+        bak = STATE_FILE.with_suffix(f".bak.{int(time.time())}")
+        try:
+            os.replace(str(STATE_FILE), str(bak))
+            print(f"  ⚠️  상태 파일 손상 → 백업: {bak}")
+        except OSError:
+            pass
+        return {"version": 1, "projects": {}}
+
+
+def save_state(state):
+    """파일 락 + Atomic write로 상태 저장."""
+    _acquire_lock()
+    try:
+        # 락 내에서 최신 상태 재로드 후 merge (R2-#2: concurrent update 방지)
+        current = load_state()
+        for key, val in state.get("projects", {}).items():
+            current["projects"][key] = val
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        tmp_path = STATE_FILE.with_suffix(".tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(current, f, ensure_ascii=False, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(str(tmp_path), str(STATE_FILE))
+    finally:
+        _release_lock()
+
+
+def get_last_hash(state, repo_key):
+    """repo_key에 해당하는 마지막 처리 커밋 해시 반환. 없으면 None."""
+    entry = state.get("projects", {}).get(repo_key)
+    return entry["last_commit_hash"] if entry else None
+
+
+def update_last_hash(state, repo_key, commit_hash):
+    """repo_key의 마지막 처리 해시와 실행 시각 업데이트."""
+    if "projects" not in state:
+        state["projects"] = {}
+    state["projects"][repo_key] = {
+        "last_commit_hash": commit_hash,
+        "last_run_at": datetime.datetime.now().isoformat()
+    }
+    return state


### PR DESCRIPTION
## Summary

- `~/.claw-log/commit_state.json`에 프로젝트별 마지막 처리 커밋 해시를 저장하여 중복 요약 방지
- `git log {last_hash}..HEAD` 범위 수집으로 이미 요약된 커밋 재처리 차단
- `--dry-run` / `--status` 에 추적 상태 반영

## 변경 파일

| 파일 | 유형 | 내용 |
|------|------|------|
| `state.py` | 신규 | Atomic write + cross-process 파일 락 + 상태 관리 모듈 |
| `main.py` | 수정 | Git 헬퍼 함수 4개 + diff 수집 확장 + 워크플로우 통합 |

## 커밋 구성

- `feat(state)`: 상태 모듈 — Atomic write (temp→os.replace+fsync), 파일 락 (O_CREAT\|O_EXCL), stale 락 자동 제거, 손상 시 .bak 백업
- `feat(main)`: Git 헬퍼 4개 — `_get_repo_key`, `_is_valid_ancestor`, `_get_latest_commit_hash`, `_count_commits_in_range`
- `feat(main)`: 통합 — diff 확장, 워크플로우, dry-run, status

## 주요 설계 결정

- **키 형식**: `repo_root::refs/heads/branch` — 브랜치 전환 시 독립 추적 (R2-#1)
- **무효 해시 복구**: `_is_valid_ancestor()` 실패(rebase/amend) 시 최근 100개 스캔 (R2-#3)
- **상태 미업데이트 조건**: truncation 발생 또는 커밋 50개 초과 시 → 다음 실행에서 재수집 (R1-#4, R2-#5)
- **저장 시점**: AI 요약 성공 후에만 `save_state()` 호출 — 실패 시 재수집 보장
- **`--days N` 모드**: 해시 추적 비활성, 기존 날짜 기반 동작 유지

## Test plan

- [ ] 첫 실행 후 `~/.claw-log/commit_state.json` 생성 확인 (`repo_root::ref` 키 형식)
- [ ] 즉시 재실행 시 "변경사항이 발견되지 않았습니다" 출력 확인
- [ ] 새 커밋 추가 후 실행 시 새 커밋만 요약됨 확인
- [ ] `claw-log --dry-run` 에서 truncated/commit_count 상태 표시 확인
- [ ] `claw-log --status` 에서 "추적상태: N개 프로젝트 커밋 추적 중" 확인
- [ ] `commit_state.json` 해시를 임의 값으로 변경 후 실행 → fallback 경고 출력 확인
- [ ] `claw-log --days 7` 실행 시 상태 파일 미변경 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)